### PR TITLE
Feat/m1 roles refactor

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-SA_PASSWORD=Admin1234!
-JWT_SECRET_KEY=academia-digital-secret-key-local-dev-2024
+SA_PASSWORD=
+JWT_SECRET_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ frontend-angular/.angular/
 # IDE
 .vscode/
 .idea/
+docs/

--- a/backend-dotnet/src/AcademiaDigital.API/Controllers/AdminController.cs
+++ b/backend-dotnet/src/AcademiaDigital.API/Controllers/AdminController.cs
@@ -10,6 +10,7 @@ namespace AcademiaDigital.API.Controllers;
 public class AdminController(
     GetUsersUseCase getUsersUseCase,
     UpdateUserRoleUseCase updateUserRoleUseCase,
+    UpdateUserActiveStatusUseCase updateUserActiveStatusUseCase,
     DeleteUserUseCase deleteUserUseCase) : ApiControllerBase
 {
     private IActionResult RequireAdmin()
@@ -42,6 +43,15 @@ public class AdminController(
         return Ok(new { success = true, user = updated });
     }
 
+    // PATCH /api/v1/admin/users/{id}/active
+    [HttpPatch("users/{id:long}/active")]
+    public async Task<IActionResult> UpdateActiveStatus(long id, [FromBody] UpdateActiveStatusRequest request, CancellationToken ct)
+    {
+        var guard = RequireAdmin(); if (guard != null) return guard;
+        var updated = await updateUserActiveStatusUseCase.ExecuteAsync(CurrentUserId!.Value, id, request.IsActive, ct);
+        return Ok(new { success = true, user = updated });
+    }
+
     // DELETE /api/v1/admin/users/{id}
     [HttpDelete("users/{id:long}")]
     public async Task<IActionResult> DeleteUser(long id, CancellationToken ct)
@@ -53,3 +63,4 @@ public class AdminController(
 }
 
 public record UpdateRoleRequest([Required] UserRole Role);
+public record UpdateActiveStatusRequest([Required] bool IsActive);

--- a/backend-dotnet/src/AcademiaDigital.API/Controllers/AuthController.cs
+++ b/backend-dotnet/src/AcademiaDigital.API/Controllers/AuthController.cs
@@ -2,6 +2,7 @@ using AcademiaDigital.API.Models;
 using AcademiaDigital.Application.UseCases.Authentication;
 using Microsoft.AspNetCore.Mvc;
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 
 namespace AcademiaDigital.API.Controllers;
 
@@ -28,7 +29,7 @@ public class AuthController(
     [HttpPost("register")]
     public async Task<IActionResult> Register([FromBody] RegisterRequest request, CancellationToken ct)
     {
-        var result = await registerUseCase.ExecuteAsync(request.Email, request.Username, request.Password, request.Dni, ct);
+        var result = await registerUseCase.ExecuteAsync(request.Email, request.Name, request.LastName, request.Password, request.Dni, ct);
         return StatusCode(StatusCodes.Status201Created, new
         {
             success = result.Success,
@@ -64,7 +65,19 @@ public record LoginRequest(
     [Required] string Password);
 
 public record RegisterRequest(
+    [property: JsonPropertyName("name")]
+    [Required] string Name,
+
+    [property: JsonPropertyName("lastname")]
+    [Required] string LastName,
+
+    [property: JsonPropertyName("email")]
     [Required][EmailAddress] string Email,
-    [Required] string Username,
+
+    [property: JsonPropertyName("password")]
     [Required][MinLength(4)] string Password,
-    string? Dni = null);
+
+    [property: JsonPropertyName("DNI")]
+    [Required]
+    [RegularExpression(@"^\d{7,8}$", ErrorMessage = "DNI must contain only numbers and have 7 or 8 digits.")]
+    string Dni);

--- a/backend-dotnet/src/AcademiaDigital.API/Middleware/ActiveSessionMiddleware.cs
+++ b/backend-dotnet/src/AcademiaDigital.API/Middleware/ActiveSessionMiddleware.cs
@@ -1,5 +1,6 @@
 using AcademiaDigital.Domain.Interfaces.Repositories;
 using AcademiaDigital.Domain.Interfaces.Services;
+using AcademiaDigital.Domain.Enums;
 
 namespace AcademiaDigital.API.Middleware;
 
@@ -27,16 +28,23 @@ public class ActiveSessionMiddleware(RequestDelegate next)
             if (tokenService.ValidateToken(token))
             {
                 var session = await sessionRepository.FindByTokenAsync(token);
+                var tokenUserId = tokenService.GetUserIdFromToken(token);
+                var tokenRole = tokenService.GetUserRoleFromToken(token);
 
-                if (session != null && session.User.IsActive)
+                if (session != null
+                    && session.User.IsActive
+                    && tokenUserId == session.UserId
+                    && tokenRole == session.User.Role)
                 {
                     context.Items["UserId"] = session.UserId;
-                    context.Items["UserRole"] = (int)session.User.Role;
-                    context.Items["IsSuperuser"] = session.User.Role == AcademiaDigital.Domain.Enums.UserRole.Admin;
+                    context.Items["UserRole"] = (int)tokenRole.Value;
+                    context.Items["IsSuperuser"] = tokenRole.Value == UserRole.Admin;
                 }
                 else
                 {
                     context.Items.Remove("UserId");
+                    context.Items.Remove("UserRole");
+                    context.Items.Remove("IsSuperuser");
                 }
             }
         }

--- a/backend-dotnet/src/AcademiaDigital.API/Middleware/ExceptionMiddleware.cs
+++ b/backend-dotnet/src/AcademiaDigital.API/Middleware/ExceptionMiddleware.cs
@@ -24,8 +24,10 @@ public class ExceptionMiddleware(RequestDelegate next, ILogger<ExceptionMiddlewa
         {
             InvalidCredentialsException e => (StatusCodes.Status401Unauthorized, e.Message),
             InactiveUserException e => (StatusCodes.Status403Forbidden, e.Message),
+            AccountLockedException e => (StatusCodes.Status423Locked, e.Message),
             ForbiddenException e => (StatusCodes.Status403Forbidden, e.Message),
             EmailAlreadyExistsException e => (StatusCodes.Status409Conflict, e.Message),
+            DniAlreadyExistsException e => (StatusCodes.Status409Conflict, e.Message),
             UserNotFoundException e => (StatusCodes.Status404NotFound, e.Message),
             SessionNotFoundException e => (StatusCodes.Status404NotFound, e.Message),
             UnauthorizedUserUpdateException e => (StatusCodes.Status403Forbidden, e.Message),

--- a/backend-dotnet/src/AcademiaDigital.API/Program.cs
+++ b/backend-dotnet/src/AcademiaDigital.API/Program.cs
@@ -22,6 +22,7 @@ builder.Services.AddScoped<UpdateUserUseCase>();
 // Admin
 builder.Services.AddScoped<GetUsersUseCase>();
 builder.Services.AddScoped<UpdateUserRoleUseCase>();
+builder.Services.AddScoped<UpdateUserActiveStatusUseCase>();
 builder.Services.AddScoped<DeleteUserUseCase>();
 
 // Certificates

--- a/backend-dotnet/src/AcademiaDigital.Application/UseCases/Admin/UpdateUserActiveStatusUseCase.cs
+++ b/backend-dotnet/src/AcademiaDigital.Application/UseCases/Admin/UpdateUserActiveStatusUseCase.cs
@@ -1,0 +1,27 @@
+using AcademiaDigital.Domain.Exceptions;
+using AcademiaDigital.Domain.Interfaces.Repositories;
+
+namespace AcademiaDigital.Application.UseCases.Admin;
+
+public class UpdateUserActiveStatusUseCase(IUserRepository userRepository, ISessionRepository sessionRepository)
+{
+    public async Task<UserSummary> ExecuteAsync(long requestingUserId, long targetUserId, bool isActive, CancellationToken ct = default)
+    {
+        if (requestingUserId == targetUserId)
+            throw new ForbiddenException("You cannot change your own active status.");
+
+        var updated = await userRepository.UpdateActiveStatusAsync(targetUserId, isActive, ct);
+
+        if (!isActive)
+            await sessionRepository.DeleteByUserAsync(targetUserId, ct);
+
+        return new UserSummary(
+            Id: updated.Id,
+            Username: updated.Username,
+            Email: updated.Email,
+            Dni: updated.Dni,
+            Role: updated.Role,
+            IsActive: updated.IsActive,
+            DateJoined: updated.DateJoined);
+    }
+}

--- a/backend-dotnet/src/AcademiaDigital.Application/UseCases/Authentication/LoginUseCase.cs
+++ b/backend-dotnet/src/AcademiaDigital.Application/UseCases/Authentication/LoginUseCase.cs
@@ -10,13 +10,40 @@ public class LoginUseCase(
     ISessionRepository sessionRepository,
     ITokenService tokenService)
 {
+    private const int MaxFailedAttempts = 5;
+    private static readonly TimeSpan LockoutDuration = TimeSpan.FromMinutes(15);
+
     public async Task<LoginResult> ExecuteAsync(string email, string password, CancellationToken ct = default)
     {
-        var user = await userRepository.AuthenticateAsync(email, password, ct)
-            ?? throw new InvalidCredentialsException();
+        var normalizedEmail = email.Trim();
+        var existingUser = await userRepository.FindByEmailAsync(normalizedEmail, ct);
+
+        if (existingUser?.LockedUntil is DateTime lockedUntil)
+        {
+            if (lockedUntil > DateTime.UtcNow)
+                throw new AccountLockedException(lockedUntil);
+
+            await userRepository.ResetLoginFailuresAsync(existingUser.Id, ct);
+        }
+
+        var user = await userRepository.AuthenticateAsync(normalizedEmail, password, ct);
+        if (user is null)
+        {
+            if (existingUser is not null)
+            {
+                var updated = await userRepository.RecordFailedLoginAsync(existingUser.Id, MaxFailedAttempts, LockoutDuration, ct);
+                if (updated.LockedUntil is DateTime newLockedUntil && updated.FailedLoginAttempts >= MaxFailedAttempts)
+                    throw new AccountLockedException(newLockedUntil);
+            }
+
+            throw new InvalidCredentialsException();
+        }
 
         if (!user.IsActive)
             throw new InactiveUserException();
+
+        if (user.FailedLoginAttempts > 0 || user.LockedUntil is not null)
+            await userRepository.ResetLoginFailuresAsync(user.Id, ct);
 
         var session = await sessionRepository.FindByUserAsync(user.Id, ct);
         string token;

--- a/backend-dotnet/src/AcademiaDigital.Application/UseCases/Authentication/RegisterUseCase.cs
+++ b/backend-dotnet/src/AcademiaDigital.Application/UseCases/Authentication/RegisterUseCase.cs
@@ -6,13 +6,20 @@ namespace AcademiaDigital.Application.UseCases.Authentication;
 
 public class RegisterUseCase(IUserRepository userRepository)
 {
-    public async Task<RegisterResult> ExecuteAsync(string email, string username, string password, string? dni = null, CancellationToken ct = default)
+    public async Task<RegisterResult> ExecuteAsync(string email, string name, string lastName, string password, string dni, CancellationToken ct = default)
     {
-        var existing = await userRepository.FindByEmailAsync(email, ct);
-        if (existing != null)
+        var normalizedEmail = email.Trim();
+        var normalizedDni = dni.Trim();
+
+        var existingEmail = await userRepository.FindByEmailAsync(normalizedEmail, ct);
+        if (existingEmail != null)
             throw new EmailAlreadyExistsException();
 
-        var user = await userRepository.CreateAsync(email, username, password, dni, UserRole.Alumno, ct);
+        var existingDni = await userRepository.FindByDniAsync(normalizedDni, ct);
+        if (existingDni != null)
+            throw new DniAlreadyExistsException();
+
+        var user = await userRepository.CreateAsync(normalizedEmail, name, lastName, password, normalizedDni, UserRole.Alumno, ct);
 
         return new RegisterResult(
             Success: true,

--- a/backend-dotnet/src/AcademiaDigital.Domain/Entities/User.cs
+++ b/backend-dotnet/src/AcademiaDigital.Domain/Entities/User.cs
@@ -13,4 +13,6 @@ public class User
     public bool IsActive { get; set; } = true;
     public DateTime DateJoined { get; set; } = DateTime.UtcNow;
     public UserRole Role { get; set; } = UserRole.Alumno;
+    public int FailedLoginAttempts { get; set; }
+    public DateTime? LockedUntil { get; set; }
 }

--- a/backend-dotnet/src/AcademiaDigital.Domain/Exceptions/AuthenticationExceptions.cs
+++ b/backend-dotnet/src/AcademiaDigital.Domain/Exceptions/AuthenticationExceptions.cs
@@ -8,10 +8,19 @@ public class InvalidCredentialsException(string message = "Invalid email or pass
 public class InactiveUserException(string message = "User account is not active")
     : AuthenticationException(message);
 
+public class AccountLockedException(DateTime lockedUntil)
+    : AuthenticationException($"Account locked. Try again after {lockedUntil:O}")
+{
+    public DateTime LockedUntil { get; } = lockedUntil;
+}
+
 public class SessionNotFoundException(string message = "Session not found")
     : AuthenticationException(message);
 
 public class EmailAlreadyExistsException(string message = "Email already taken")
+    : AuthenticationException(message);
+
+public class DniAlreadyExistsException(string message = "DNI already taken")
     : AuthenticationException(message);
 
 public class UnauthorizedUserUpdateException(string message = "Error updating user")

--- a/backend-dotnet/src/AcademiaDigital.Domain/Interfaces/Repositories/IUserRepository.cs
+++ b/backend-dotnet/src/AcademiaDigital.Domain/Interfaces/Repositories/IUserRepository.cs
@@ -7,12 +7,16 @@ public interface IUserRepository
 {
     Task<User?> FindByIdAsync(long id, CancellationToken ct = default);
     Task<User?> FindByEmailAsync(string email, CancellationToken ct = default);
+    Task<User?> FindByDniAsync(string dni, CancellationToken ct = default);
     Task<User?> AuthenticateAsync(string email, string password, CancellationToken ct = default);
-    Task<User> CreateAsync(string email, string username, string password, string? dni = null, UserRole role = UserRole.Alumno, CancellationToken ct = default);
+    Task<User> CreateAsync(string email, string username, string lastName, string password, string dni, UserRole role = UserRole.Alumno, CancellationToken ct = default);
+    Task<User> RecordFailedLoginAsync(long userId, int maxAttempts, TimeSpan lockoutDuration, CancellationToken ct = default);
+    Task ResetLoginFailuresAsync(long userId, CancellationToken ct = default);
     Task<User> UpdateAsync(User user, CancellationToken ct = default);
 
     // Admin methods
     Task<(List<User> Users, int Total)> GetAllAsync(string? search, UserRole? role, int skip, int take, CancellationToken ct = default);
     Task<User> UpdateRoleAsync(long userId, UserRole newRole, CancellationToken ct = default);
+    Task<User> UpdateActiveStatusAsync(long userId, bool isActive, CancellationToken ct = default);
     Task DeleteAsync(long userId, CancellationToken ct = default);
 }

--- a/backend-dotnet/src/AcademiaDigital.Domain/Interfaces/Services/ITokenService.cs
+++ b/backend-dotnet/src/AcademiaDigital.Domain/Interfaces/Services/ITokenService.cs
@@ -1,4 +1,5 @@
 using AcademiaDigital.Domain.Entities;
+using AcademiaDigital.Domain.Enums;
 
 namespace AcademiaDigital.Domain.Interfaces.Services;
 
@@ -7,4 +8,5 @@ public interface ITokenService
     string GenerateToken(User user);
     bool ValidateToken(string token);
     long? GetUserIdFromToken(string token);
+    UserRole? GetUserRoleFromToken(string token);
 }

--- a/backend-dotnet/src/AcademiaDigital.Infrastructure/Migrations/20260524203000_AddUniqueUserDniIndex.cs
+++ b/backend-dotnet/src/AcademiaDigital.Infrastructure/Migrations/20260524203000_AddUniqueUserDniIndex.cs
@@ -1,0 +1,33 @@
+using AcademiaDigital.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AcademiaDigital.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    [DbContext(typeof(AppDbContext))]
+    [Migration("20260524203000_AddUniqueUserDniIndex")]
+    public partial class AddUniqueUserDniIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_Users_dni",
+                table: "Users",
+                column: "dni",
+                unique: true,
+                filter: "[dni] IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Users_dni",
+                table: "Users");
+        }
+    }
+}

--- a/backend-dotnet/src/AcademiaDigital.Infrastructure/Migrations/20260524204500_AddUserLoginLockout.cs
+++ b/backend-dotnet/src/AcademiaDigital.Infrastructure/Migrations/20260524204500_AddUserLoginLockout.cs
@@ -1,0 +1,44 @@
+using System;
+using AcademiaDigital.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AcademiaDigital.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    [DbContext(typeof(AppDbContext))]
+    [Migration("20260524204500_AddUserLoginLockout")]
+    public partial class AddUserLoginLockout : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "failed_login_attempts",
+                table: "Users",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "locked_until",
+                table: "Users",
+                type: "datetime2",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "failed_login_attempts",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "locked_until",
+                table: "Users");
+        }
+    }
+}

--- a/backend-dotnet/src/AcademiaDigital.Infrastructure/Migrations/AppDbContextModelSnapshot.cs
+++ b/backend-dotnet/src/AcademiaDigital.Infrastructure/Migrations/AppDbContextModelSnapshot.cs
@@ -687,6 +687,12 @@ namespace AcademiaDigital.Infrastructure.Migrations
                         .HasColumnType("nvarchar(254)")
                         .HasColumnName("email");
 
+                    b.Property<int>("FailedLoginAttempts")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int")
+                        .HasDefaultValue(0)
+                        .HasColumnName("failed_login_attempts");
+
                     b.Property<bool>("IsActive")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bit")
@@ -702,6 +708,10 @@ namespace AcademiaDigital.Infrastructure.Migrations
                         .HasMaxLength(255)
                         .HasColumnType("nvarchar(255)")
                         .HasColumnName("last_name");
+
+                    b.Property<DateTime?>("LockedUntil")
+                        .HasColumnType("datetime2")
+                        .HasColumnName("locked_until");
 
                     b.Property<string>("Password")
                         .IsRequired()
@@ -725,6 +735,10 @@ namespace AcademiaDigital.Infrastructure.Migrations
 
                     b.HasIndex("Email")
                         .IsUnique();
+
+                    b.HasIndex("Dni")
+                        .IsUnique()
+                        .HasFilter("[dni] IS NOT NULL");
 
                     b.ToTable("Users", (string)null);
                 });

--- a/backend-dotnet/src/AcademiaDigital.Infrastructure/Persistence/Configurations/UserConfiguration.cs
+++ b/backend-dotnet/src/AcademiaDigital.Infrastructure/Persistence/Configurations/UserConfiguration.cs
@@ -18,8 +18,11 @@ public class UserConfiguration : IEntityTypeConfiguration<User>
         builder.HasIndex(u => u.Email).IsUnique();
         builder.Property(u => u.Password).HasColumnName("password").HasMaxLength(128).IsRequired();
         builder.Property(u => u.Dni).HasColumnName("dni").HasMaxLength(20).IsRequired(false);
+        builder.HasIndex(u => u.Dni).IsUnique().HasFilter("[dni] IS NOT NULL");
         builder.Property(u => u.IsActive).HasColumnName("is_active").HasDefaultValue(true);
         builder.Property(u => u.DateJoined).HasColumnName("date_joined");
         builder.Property(u => u.Role).HasColumnName("role");
+        builder.Property(u => u.FailedLoginAttempts).HasColumnName("failed_login_attempts").HasDefaultValue(0);
+        builder.Property(u => u.LockedUntil).HasColumnName("locked_until");
     }
 }

--- a/backend-dotnet/src/AcademiaDigital.Infrastructure/Persistence/Repositories/UserRepository.cs
+++ b/backend-dotnet/src/AcademiaDigital.Infrastructure/Persistence/Repositories/UserRepository.cs
@@ -3,6 +3,7 @@ using AcademiaDigital.Domain.Enums;
 using AcademiaDigital.Domain.Exceptions;
 using AcademiaDigital.Domain.Interfaces.Repositories;
 using AcademiaDigital.Domain.Interfaces.Services;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 
 namespace AcademiaDigital.Infrastructure.Persistence.Repositories;
@@ -13,31 +14,84 @@ public class UserRepository(AppDbContext db, IPasswordHasher passwordHasher) : I
         => await db.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Id == id, ct);
 
     public async Task<User?> FindByEmailAsync(string email, CancellationToken ct = default)
-        => await db.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Email == email, ct);
+        => await db.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Email == email.Trim(), ct);
+
+    public async Task<User?> FindByDniAsync(string dni, CancellationToken ct = default)
+        => await db.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Dni == dni.Trim(), ct);
 
     public async Task<User?> AuthenticateAsync(string email, string password, CancellationToken ct = default)
     {
-        var user = await db.Users.FirstOrDefaultAsync(u => u.Email == email, ct);
+        var user = await db.Users.FirstOrDefaultAsync(u => u.Email == email.Trim(), ct);
         if (user is null) return null;
         return passwordHasher.Verify(password, user.Password) ? user : null;
     }
 
-    public async Task<User> CreateAsync(string email, string username, string password, string? dni = null, UserRole role = UserRole.Alumno, CancellationToken ct = default)
+    public async Task<User> CreateAsync(string email, string username, string lastName, string password, string dni, UserRole role = UserRole.Alumno, CancellationToken ct = default)
     {
         var user = new User
         {
-            Email = email,
-            Username = username,
+            Email = email.Trim(),
+            Username = username.Trim(),
+            LastName = lastName.Trim(),
             Password = passwordHasher.Hash(password),
-            Dni = string.IsNullOrWhiteSpace(dni) ? null : dni.Trim(),
+            Dni = dni.Trim(),
             IsActive = true,
             DateJoined = DateTime.UtcNow,
             Role = role
         };
 
         db.Users.Add(user);
+        try
+        {
+            await db.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex, "email"))
+        {
+            throw new EmailAlreadyExistsException();
+        }
+        catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex, "dni"))
+        {
+            throw new DniAlreadyExistsException();
+        }
+
+        return user;
+    }
+
+    public async Task<User> RecordFailedLoginAsync(long userId, int maxAttempts, TimeSpan lockoutDuration, CancellationToken ct = default)
+    {
+        var user = await db.Users.FindAsync([userId], ct)
+            ?? throw new UserNotFoundException(userId);
+
+        user.FailedLoginAttempts++;
+
+        if (user.FailedLoginAttempts >= maxAttempts)
+            user.LockedUntil = DateTime.UtcNow.Add(lockoutDuration);
+
         await db.SaveChangesAsync(ct);
         return user;
+    }
+
+    public async Task ResetLoginFailuresAsync(long userId, CancellationToken ct = default)
+    {
+        var user = await db.Users.FindAsync([userId], ct)
+            ?? throw new UserNotFoundException(userId);
+
+        user.FailedLoginAttempts = 0;
+        user.LockedUntil = null;
+        await db.SaveChangesAsync(ct);
+    }
+
+    private static bool IsUniqueConstraintViolation(DbUpdateException ex, string column)
+    {
+        var message = ex.InnerException?.Message ?? ex.Message;
+        var isUniqueViolation = ex.InnerException is SqlException { Number: 2601 or 2627 }
+            || message.Contains("duplicate", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("duplicada", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("unique", StringComparison.OrdinalIgnoreCase);
+
+        return isUniqueViolation
+            && (message.Contains(column, StringComparison.OrdinalIgnoreCase)
+                || message.Contains($"IX_Users_{column}", StringComparison.OrdinalIgnoreCase));
     }
 
     public async Task<User> UpdateAsync(User user, CancellationToken ct = default)
@@ -77,6 +131,19 @@ public class UserRepository(AppDbContext db, IPasswordHasher passwordHasher) : I
         var user = await db.Users.FindAsync([userId], ct)
             ?? throw new UserNotFoundException(userId);
         user.Role = newRole;
+        await db.SaveChangesAsync(ct);
+        return user;
+    }
+
+    public async Task<User> UpdateActiveStatusAsync(long userId, bool isActive, CancellationToken ct = default)
+    {
+        var user = await db.Users.FindAsync([userId], ct)
+            ?? throw new UserNotFoundException(userId);
+
+        user.IsActive = isActive;
+        if (!isActive)
+            user.LockedUntil = null;
+
         await db.SaveChangesAsync(ct);
         return user;
     }

--- a/backend-dotnet/src/AcademiaDigital.Infrastructure/Services/JwtTokenService.cs
+++ b/backend-dotnet/src/AcademiaDigital.Infrastructure/Services/JwtTokenService.cs
@@ -2,6 +2,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
 using AcademiaDigital.Domain.Entities;
+using AcademiaDigital.Domain.Enums;
 using AcademiaDigital.Domain.Interfaces.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.IdentityModel.Tokens;
@@ -67,6 +68,24 @@ public class JwtTokenService(IConfiguration configuration) : ITokenService
             var idClaim = jwt.Claims.FirstOrDefault(c => c.Type == "id");
 
             return idClaim != null && long.TryParse(idClaim.Value, out var id) ? id : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public UserRole? GetUserRoleFromToken(string token)
+    {
+        try
+        {
+            var handler = new JwtSecurityTokenHandler();
+            var jwt = handler.ReadJwtToken(token);
+            var roleClaim = jwt.Claims.FirstOrDefault(c => c.Type == "role");
+
+            return roleClaim != null && int.TryParse(roleClaim.Value, out var role)
+                ? (UserRole)role
+                : null;
         }
         catch
         {


### PR DESCRIPTION
## Resumen

Se agregan mejoras de seguridad y administración de usuarios en el backend.

### Cambios principales

- Se actualizó el payload de `POST /api/v1/users/register` para solicitar:
  - `name`
  - `lastname`
  - `email`
  - `password`
  - `DNI`

- Se agregaron validaciones en registro:
  - Email único.
  - DNI único.
  - DNI obligatorio con formato numérico de 7 u 8 dígitos.

- Se agregó índice único para `dni` en la tabla `Users`.

- Se agregó lógica de bloqueo en `/api/v1/users/login`:
  - Máximo 5 intentos fallidos.
  - Bloqueo de cuenta por 15 minutos.
  - Reseteo de intentos al login exitoso.

- Se reforzó la validación de endpoints admin:
  - Requieren JWT válido.
  - Requieren sesión activa.
  - Requieren rol `Admin = 3`.
  - Se valida que el rol del token coincida con el usuario en DB.

- Se agregó endpoint admin para activar/desactivar usuarios:
  - `PATCH /api/v1/admin/users/{id}/active`
  - Al desactivar un usuario, se eliminan sus sesiones activas.

### Validación

- Build ejecutado correctamente:
  - `dotnet build backend-dotnet/src/AcademiaDigital.API/AcademiaDigital.API.csproj`
- Se validaron flujos de registro, duplicados, login lockout y acceso admin.